### PR TITLE
Save and send `commit_id` when submitting a review

### DIFF
--- a/src/prr.rs
+++ b/src/prr.rs
@@ -111,9 +111,8 @@ impl Prr {
             bail!("No review comments");
         }
 
-        let body = json!({
+        let mut body = json!({
             "body": review_comment,
-            "commit_id": metadata.get_commit_id(),
             "event": match review_action {
                 ReviewAction::Approve => "APPROVE",
                 ReviewAction::RequestChanges => "REQUEST_CHANGES",
@@ -147,6 +146,14 @@ impl Prr {
                 })
                 .collect::<Vec<Value>>(),
         });
+        if let Some(id) = metadata.get_commit_id() {
+            match &mut body {
+                serde_json::Value::Object(obj) => {
+                    obj.insert("commit_id".to_string(), json!(id));
+                }
+                _ => {}
+            }
+        }
 
         if debug {
             println!("{}", serde_json::to_string_pretty(&body)?);

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -77,14 +77,29 @@ impl Prr {
         pr_num: u64,
         force: bool,
     ) -> Result<Review> {
-        let diff = self
-            .crab
-            .pulls(owner, repo)
+        let pr_handler = self.crab.pulls(owner, repo);
+
+        let diff = pr_handler
             .get_diff(pr_num)
             .await
             .context("Failed to fetch diff")?;
 
-        Review::new(&self.workdir()?, diff, owner, repo, pr_num, force)
+        let commit_id = pr_handler
+            .get(pr_num)
+            .await
+            .context("Failed to fetch commit ID")?
+            .head
+            .sha;
+
+        Review::new(
+            &self.workdir()?,
+            diff,
+            owner,
+            repo,
+            pr_num,
+            commit_id,
+            force,
+        )
     }
 
     pub async fn submit_pr(&self, owner: &str, repo: &str, pr_num: u64, debug: bool) -> Result<()> {

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -105,6 +105,7 @@ impl Prr {
     pub async fn submit_pr(&self, owner: &str, repo: &str, pr_num: u64, debug: bool) -> Result<()> {
         let review = Review::new_existing(&self.workdir()?, owner, repo, pr_num);
         let (review_action, review_comment, inline_comments) = review.comments()?;
+        let metadata = review.get_metadata()?;
 
         if review_comment.is_empty() && inline_comments.is_empty() {
             bail!("No review comments");
@@ -112,6 +113,7 @@ impl Prr {
 
         let body = json!({
             "body": review_comment,
+            "commit_id": metadata.get_commit_id(),
             "event": match review_action {
                 ReviewAction::Approve => "APPROVE",
                 ReviewAction::RequestChanges => "REQUEST_CHANGES",

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -147,11 +147,8 @@ impl Prr {
                 .collect::<Vec<Value>>(),
         });
         if let Some(id) = metadata.get_commit_id() {
-            match &mut body {
-                serde_json::Value::Object(obj) => {
-                    obj.insert("commit_id".to_string(), json!(id));
-                }
-                _ => {}
+            if let serde_json::Value::Object(ref mut obj) = body {
+                obj.insert("commit_id".to_string(), json!(id));
             }
         }
 

--- a/src/review.rs
+++ b/src/review.rs
@@ -29,6 +29,8 @@ struct ReviewMetadata {
     original: String,
     /// Time (seconds since epoch) the review file was last submitted
     submitted: Option<u64>,
+    /// The commit hash of the PR at the time the review was started
+    commit_id: Option<String>,
 }
 
 fn prefix_lines(s: &str, prefix: &str) -> String {
@@ -49,6 +51,7 @@ impl Review {
         owner: &str,
         repo: &str,
         pr_num: u64,
+        commit_id: String,
         force: bool,
     ) -> Result<Review> {
         let review = Review {
@@ -94,6 +97,7 @@ impl Review {
         let metadata = ReviewMetadata {
             original: diff,
             submitted: None,
+            commit_id: Some(commit_id),
         };
         let json = serde_json::to_string(&metadata)?;
         let metadata_path = review.metadata_path();

--- a/src/review.rs
+++ b/src/review.rs
@@ -34,7 +34,7 @@ pub(crate) struct ReviewMetadata {
 }
 impl ReviewMetadata {
     pub(crate) fn get_commit_id(&self) -> Option<&str> {
-        self.commit_id.as_ref().map(|v| v.as_str())
+        self.commit_id.as_deref()
     }
 }
 


### PR DESCRIPTION
This should fix #8, hopefully improving the situation where someone pushes to a PR during your review of a patch. :) 

## Changes
- Fetch diff metadata when getting a new PR
- Store `commit_id` in metadata
- Expose `ReviewMetadata` outside just the `review` module
- Break logic to load `ReviewMetadata` out to a function