### PR TITLE
oneliners have deviant headers when adding files

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -178,7 +178,7 @@ fn parse_hunk_start(line: &str) -> Result<Option<(u64, u64)>> {
                 if hunk_start_line_left == 0 {
                     "0"
                 } else {
-                    unreachable!("")
+                    unreachable!("Unexpected non-zero left-hand-side of git diff header. Expected 0.")
                 }
             )
             .parse()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -622,6 +622,20 @@ mod tests {
     }
 
     #[test]
+    fn add_file() {
+        let input = include_str!("../testdata/add_oneliner");
+        let expected = vec![
+        Comment::Inline(InlineComment {
+            file: "foo.rs".to_string(),
+            line: LineLocation::Right(1),
+            start_line: None,
+            comment: "Comment 1".to_string(),
+        })];
+
+        test(input, &expected);
+    }
+
+    #[test]
     fn deleted_file() {
         let input = include_str!("../testdata/deleted_file");
         let expected = vec![Comment::Inline(InlineComment {

--- a/testdata/add_oneliner
+++ b/testdata/add_oneliner
@@ -4,6 +4,9 @@
 > --- /dev/null
 > +++ b/foo.rs
 > @@ -0,0 +1 @@
-> +License: Unlicense
 
 Comment 1
+
+> +License: Unlicense
+
+Comment 2

--- a/testdata/add_oneliner
+++ b/testdata/add_oneliner
@@ -1,0 +1,9 @@
+> diff --git a/foo.rs b/foo.rs
+> new file mode 100644
+> index 0000000..5a64612
+> --- /dev/null
+> +++ b/foo.rs
+> @@ -0,0 +1 @@
+> +License: Unlicense
+
+Comment 1


### PR DESCRIPTION
I encountered a PR that caused #11, after some digging it turns out, oneliner files (at least those) have deviant right hand side header.

The PR adds a regression test and fixes the issue by adding another named capture that is evaluated as a fallback since it should happen rarely.