### PR TITLE
Add local config file

### DIFF
--- a/src/prr.rs
+++ b/src/prr.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -31,9 +30,6 @@ lazy_static! {
 }
 
 const GITHUB_BASE_URL: &str = "https://api.github.com";
-
-/// The name of the local configuration file
-pub const LOCAL_CONFIG_FILE_NAME: &str = ".prr.toml";
 
 #[derive(Debug, Deserialize)]
 struct PrrConfig {
@@ -67,21 +63,6 @@ pub struct Prr {
     crab: Octocrab,
 }
 
-/// Returns if exists the config file for the current project
-fn find_project_config_file() -> Option<PathBuf> {
-    env::current_dir().ok().and_then(|mut path| loop {
-        path.push(LOCAL_CONFIG_FILE_NAME);
-        if path.exists() {
-            return Some(path);
-        }
-
-        path.pop();
-        if !path.pop() {
-            return None;
-        }
-    })
-}
-
 impl Prr {
     /// Create a new Prr object using the main config and/or the local config.
     /// If a local config has the `[prr]` section use this one instead of the main config.
@@ -90,9 +71,9 @@ impl Prr {
     ///
     /// A `[prr]` redefition must be complete; if not, panics with a
     /// `redefinition of table `prr` for key `prr` at ...`
-    pub fn new(config_path: &Path) -> Result<Prr> {
+    pub fn new(config_path: &Path, local_config_path: Option<PathBuf>) -> Result<Prr> {
         let config_contents = fs::read_to_string(config_path).context("Failed to read config")?;
-        let local_config_contents = if let Some(project_config_path) = find_project_config_file() {
+        let local_config_contents = if let Some(project_config_path) = local_config_path {
             let content =
                 fs::read_to_string(project_config_path).context("Failed to read local config")?;
 

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -33,7 +33,7 @@ lazy_static! {
 const GITHUB_BASE_URL: &str = "https://api.github.com";
 
 /// The name of the local configuration file
-pub const CONFIG_RC_FILE_NAME: &str = ".prrc";
+pub const LOCAL_CONFIG_FILE_NAME: &str = ".prr.toml";
 
 #[derive(Debug, Deserialize)]
 struct PrrConfig {
@@ -71,7 +71,7 @@ pub struct Prr {
 /// Returns if exists the config file for the current project
 fn find_project_config_file() -> Option<PathBuf> {
     env::current_dir().ok().and_then(|mut path| loop {
-        path.push(CONFIG_RC_FILE_NAME);
+        path.push(LOCAL_CONFIG_FILE_NAME);
         if path.exists() {
             return Some(path);
         }

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -146,8 +146,8 @@ impl Prr {
             Ok((owner, repo, pr_nr))
         };
 
-        let repo = if self.local.is_some() {
-            let url = self.local.as_ref().unwrap().repository.clone();
+        let repo = if let Some(local_config) = &self.local {
+            let url = local_config.repository.clone();
 
             if url.ends_with('/') {
                 format!("{}{}", url, s)


### PR DESCRIPTION
Hi all :wave:

This PR adds a local config file for a project. So, into the directory you can create a file named `.prr.toml` with this syntax below

```
[local]
repository = "danobi/prr-test-repo"
```

so to call commands just by PR number.
Call `prr get 6` instead of `prr danobi/prr-test-repo/6`

Also, if you re-define the `[prr]` section, this will override the main config file. Eg:

```
[prr]
workdir = "/tmp"
token = "..."

[local]
repository = "danobi/prr-test-repo"
```

will use `/tmp` folder as "reviews folder" only for this repository.