### PR TITLE
Fix diff parsing for one-line pre or post-image

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,7 @@ lazy_static! {
     //
     //      `@@ -731,7 +731,7 @@[...]`
     //
-    static ref HUNK_START: Regex = Regex::new(r"^@@ -(?P<lstart>\d+),(?P<llen>\d+) \+(?:(?P<rstart>\d+),)?(?P<rlen>\d+) @@").unwrap();
+    static ref HUNK_START: Regex = Regex::new(r"^@@ -(?P<lstart>\d+)(?:,(?P<llen>\d+))? \+(?P<rstart>\d+)(?:,(?P<rlen>\d+))? @@").unwrap();
     // Regex for start of a file diff. The start of a file diff should look like:
     //
     //      `diff --git a/ch1.txt b/ch1.txt`
@@ -742,8 +742,8 @@ mod tests {
         let captures = HUNK_START
             .captures("@@ -0,0 +1 @@")
             .expect("Must match regex.");
-        assert!(captures.name("rstart").is_none());
-        assert_eq!(captures.name("rlen").unwrap().as_str(), "1");
+        assert_eq!(captures.name("rstart").unwrap().as_str(), "1");
+        assert!(captures.name("rlen").is_none());
         assert_eq!(captures.name("lstart").unwrap().as_str(), "0");
         assert_eq!(captures.name("llen").unwrap().as_str(), "0");
     }
@@ -757,5 +757,16 @@ mod tests {
         assert_eq!(captures.name("rlen").unwrap().as_str(), "1");
         assert_eq!(captures.name("lstart").unwrap().as_str(), "0");
         assert_eq!(captures.name("llen").unwrap().as_str(), "7");
+    }
+
+    #[test]
+    fn hunk_only_one_line_on_each_side() {
+        let captures = HUNK_START
+            .captures("@@ -5 +5 @@")
+            .expect("Must match regex.");
+        assert_eq!(captures.name("rstart").unwrap().as_str(), "5");
+        assert!(captures.name("rlen").is_none());
+        assert_eq!(captures.name("lstart").unwrap().as_str(), "5");
+        assert!(captures.name("llen").is_none());
     }
 }


### PR DESCRIPTION
I saw a crash:

	thread 'main' panicked at src/parser.rs:182:21:
	internal error: entered unreachable code: Unexpected non-zero left-hand-side of git diff header. Expected 0.

Turns out that given hunk header

	@@ -1,2 +3 @@

commit 3e9c247 (oneliners have deviant headers when adding files
(#12), 2022-08-18) interprets 3 as the length of the post-image.
This is wrong; 3 is the line where the post-image starts.
The length is implied to be 1 if omitted.

Such one-line diffs can be created with

	$ printf '0\n1\n' > 1
	$ printf '0\n2\n2' > 2
	$ git diff --no-index 1 2 -U0
	diff --git a/1 b/2
	index d00491f..0cfbf08 100644
	--- a/1
	+++ b/2
	@@ -2 +2 @@
	-1
	+2
