### PR TITLE
Allow approving PRs with no comment

### DIFF
--- a/src/prr.rs
+++ b/src/prr.rs
@@ -198,7 +198,10 @@ impl Prr {
         let (review_action, review_comment, inline_comments) = review.comments()?;
         let metadata = review.get_metadata()?;
 
-        if review_comment.is_empty() && inline_comments.is_empty() {
+        if review_comment.is_empty()
+            && inline_comments.is_empty()
+            && review_action != ReviewAction::Approve
+        {
             bail!("No review comments");
         }
 


### PR DESCRIPTION
If you request changes or comment, the GH API requires at least one comment. This is not true for approvals. So allow comment-less approvals.

This closes #27.