### PR TITLE
Add support for file-level comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Syntax: Non-whitespace, non-quoted text at the beginning of the review file.
 
 [Example](examples/review_comment.prr)
 
+#### File comment
+
+Description: File-level comment. You only get one of these per file.
+
+Syntax: Non-whitespace, non-quoted text immediately following the `diff --git` header
+
+[Example](examples/file_comment.prr)
+
 #### Inline comment
 
 Description: Inline comment attached to a specific line of the diff.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Syntax: Non-whitespace, non-quoted text at the beginning of the review file.
 
 #### File comment
 
-Description: File-level comment. You only get one of these per file.
+Description: File-level comment.
 
 Syntax: Non-whitespace, non-quoted text immediately following the `diff --git` header
 

--- a/examples/file_comment.prr
+++ b/examples/file_comment.prr
@@ -1,0 +1,34 @@
+> diff --git a/ch2.txt b/ch2.txt
+
+This is a file-level comment on ch2.txt
+
+> index 4d729e6..2641120 100644
+> --- a/ch2.txt
+> +++ b/ch2.txt
+> @@ -2,13 +2,6 @@ CHAPTER 2. WAGING WAR
+>  
+>  1.  Sun Tzu said: In the operations of war, where there are in the field a thousand swift chariots, as many heavy chariots, and a hundred thousand mail-clad soldiers, with provisions enough to carry them a thousand LI, the expenditure at home and at the front, including entertainment of guests, small items such as glue and paint, and sums spent on chariots and armor, will reach the total of a thousand ounces of silver per day. Such is the cost of raising an army of 100,000 men. 
+>  
+> -2. When you engage in actual fighting, if victory is long in coming, then men's weapons will grow dull and their ardor will be damped. If you lay siege to a town, you will exhaust your strength. 
+> -
+> -3. Again, if the campaign is protracted, the resources of the State will not be equal to the strain. 
+> -
+> -4. Now, when your weapons are dulled, your ardor damped, your strength exhausted and your treasure spent, other chieftains will spring up to take advantage of your extremity. Then no man, however wise, will be able to avert the consequences that must ensue. 
+> -
+> -5. Thus, though we have heard of stupid haste in war, cleverness has never been seen associated with long delays. 
+>  
+>  6. There is no instance of a country having benefited from prolonged warfare. 
+>  
+> @@ -30,6 +23,11 @@ CHAPTER 2. WAGING WAR
+>  
+>  16. Now in order to kill the enemy, our men must be roused to anger; that there may be advantage from defeating the enemy, they must have their rewards. 
+>  
+> +asdf
+> +asdf
+> +asdf
+> +adsf
+> +
+>  17. Therefore in chariot fighting, when ten or more chariots have been taken, those should be rewarded who took the first. Our own flags should be substituted for those of the enemy, and the chariots mingled and used in conjunction with ours. The captured soldiers should be kindly treated and kept. 
+>  
+>  18. This is called, using the conquered foe to augment one's own strength. 
+

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -260,7 +260,9 @@ impl Prr {
                     json_comment
                 }).chain(file_comments.iter().map(|c| {
                     json!({
+                        // FIXME: Fix this, it outputs a comment on the hunk, not the file level.
                         "path": c.file,
+                        "position": 0,
                         "body": c.comment,
                     })
                 }))

--- a/testdata/file_comment
+++ b/testdata/file_comment
@@ -1,0 +1,48 @@
+> diff --git a/libbpf-cargo/src/btf/btf.rs b/libbpf-cargo/src/btf/btf.rs
+
+This is a file-level comment!
+
+> index a26b2a5..fffb281 100644
+> --- a/libbpf-cargo/src/btf/btf.rs
+> +++ b/libbpf-cargo/src/btf/btf.rs
+> @@ -731,7 +731,7 @@ impl<'a> Btf<'a> {
+>      fn load_type(&mut self, data: &'a [u8]) -> Result<BtfType<'a>> {
+>          let t = data.pread::<btf_type>(0)?;
+>          let extra = &data[size_of::<btf_type>()..];
+> -        let kind = (t.info >> 24) & 0xf;
+> +        let kind = (t.info >> 24) & 0x1f;
+>  
+>          match BtfKind::try_from(kind)? {
+>              BtfKind::Void => {
+> diff --git a/libbpf-cargo/src/test.rs b/libbpf-cargo/src/test.rs
+> index 5b08843..82a0586 100644
+> --- a/libbpf-cargo/src/test.rs
+> +++ b/libbpf-cargo/src/test.rs
+> @@ -2145,3 +2145,27 @@ pub struct __anon_3 {
+>  
+>      assert_definition(&btf, struct_bpf_sock_tuple, expected_output);
+>  }
+> +
+> +#[test]
+> +fn test_btf_dump_float() {
+> +    let prog_text = r#"
+> +float f = 2.16;
+> +double d = 12.15;
+> +"#;
+> +
+> +    let btf = build_btf_prog(prog_text);
+> +
+> +    let f = find_type_in_btf!(btf, Var, "f");
+> +    let d = find_type_in_btf!(btf, Var, "d");
+> +
+> +    assert_eq!(
+> +        "f32",
+> +        btf.type_declaration(f)
+> +            .expect("Failed to generate f decl")
+> +    );
+> +    assert_eq!(
+> +        "f64",
+> +        btf.type_declaration(d)
+> +            .expect("Failed to generate d decl")
+> +    );
+> +}


### PR DESCRIPTION
This PR adds support for file-level comments by commenting below the `diff --git` line, see the documentation for more usage details.

Note: I haven't actually tested the GitHub API portion of this yet, in case it fails catastrophically I didn't want to test on anything too "real". So I'm going to try it on this PR and see what happens.

Fixes #32
