### PR TITLE
Add `local.workdir` config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ sub-directories.
 * `local.repository`: A string in format of `${ORG}/${REPO}` (optional)
     * If specified, you may omit the `${ORG}/${REPO}` from PR string arguments.
       For example, you may run `prr get 6` instead of `prr get danobi/prr/6`.
+* `local.workdir`: Local workdir override (optional)
+    * See `prr.workdir`
+    * Relative paths are interpreted as relative to the local config file
 
 This table may not be specified in both a local config file and the global
 config file.

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -162,7 +162,12 @@ impl Prr {
                 bail!("Invalid workdir={wd}: may not use '~'");
             }
 
-            return Ok(Path::new(wd).to_path_buf());
+            let p = Path::new(wd).to_path_buf();
+            if !p.is_absolute() {
+                bail!("Invalid workdir={wd}: must be absolute path");
+            }
+
+            return Ok(p);
         }
 
         // Default workdir


### PR DESCRIPTION
`local.workdir` overrides the global `workdir` config. This allows per-directory workdir configuration.

Note this PR also makes a backwards incompatible change to disallow relative paths in `*.workdir` configs.