### PR TITLE
Refactor Github specific code into own backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ name = "prr"
 version = "0.10.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "git2",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0"
 tokio = { version = "1.17", default-features = false, features = ["macros", "rt-multi-thread"] }
 toml = "0.5"
 xdg = "2.4"
+async-trait = "0.1.74"
 
 [dev-dependencies]
 tempfile = "3.8.1"

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1,0 +1,122 @@
+use crate::backend::{Backend, ReviewInfo};
+use crate::parser::FileComment;
+use crate::prr::Config;
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+use octocrab::Octocrab;
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+pub struct Github {
+    crab: Octocrab,
+}
+
+impl Github {
+    pub fn new(config: &Config) -> Result<Self> {
+        let crab = Octocrab::builder()
+            .personal_token(config.prr.token.clone())
+            .base_url(config.url())
+            .context("Failed to parse github base URL")?
+            .build()
+            .context("Failed to create GH client")?;
+
+        Ok(Github { crab })
+    }
+}
+
+#[async_trait]
+impl Backend for Github {
+    async fn get_pr_info(&self, owner: &str, repo: &str, pr_num: u64) -> Result<ReviewInfo> {
+        let pr_handler = self.crab.pulls(owner, repo);
+
+        let diff = pr_handler
+            .get_diff(pr_num)
+            .await
+            .context("Failed to fetch diff")?;
+
+        let commit = pr_handler
+            .get(pr_num)
+            .await
+            .context("Failed to fetch commit ID")?
+            .head
+            .sha;
+
+        Ok(ReviewInfo { diff, commit })
+    }
+
+    async fn submit_review(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_num: u64,
+        body: &Value,
+    ) -> Result<()> {
+        let path = format!("repos/{}/{}/pulls/{}/reviews", owner, repo, pr_num);
+        match self
+            .crab
+            ._post(self.crab.absolute_url(path)?, Some(body))
+            .await
+        {
+            Ok(resp) => {
+                let status = resp.status();
+                if status != StatusCode::OK {
+                    let text = resp
+                        .text()
+                        .await
+                        .context("Failed to decode failed response")?;
+                    bail!("Error during POST: Status code: {}, Body: {}", status, text);
+                }
+
+                Ok(())
+            }
+            // GH is known to send unescaped control characters in JSON responses which
+            // serde will fail to parse (not that it should succeed)
+            Err(octocrab::Error::Json {
+                source: _,
+                backtrace: _,
+            }) => bail!("Warning: GH response had invalid JSON"),
+            Err(e) => bail!("Error during POST: {}", e),
+        }
+    }
+
+    async fn submit_file_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_num: u64,
+        commit_id: &str,
+        fc: &FileComment,
+    ) -> Result<()> {
+        let body = json!({
+            "body": fc.comment,
+            "commit_id": commit_id,
+            "path": fc.file,
+            "subject_type": "file",
+        });
+        let path = format!("repos/{}/{}/pulls/{}/comments", owner, repo, pr_num);
+        match self
+            .crab
+            ._post(self.crab.absolute_url(path)?, Some(&body))
+            .await
+        {
+            Ok(resp) => {
+                let status = resp.status();
+                if status != StatusCode::CREATED {
+                    let text = resp
+                        .text()
+                        .await
+                        .context("Failed to decode failed response")?;
+                    bail!("Error during POST: Status code: {}, Body: {}", status, text);
+                }
+                Ok(())
+            }
+            // GH is known to send unescaped control characters in JSON responses which
+            // serde will fail to parse (not that it should succeed)
+            Err(octocrab::Error::Json {
+                source: _,
+                backtrace: _,
+            }) => bail!("Warning: GH response had invalid JSON"),
+            Err(e) => bail!("Error during POST: {}", e),
+        }
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,0 +1,33 @@
+use crate::parser::FileComment;
+use crate::prr::Config;
+use anyhow::Result;
+use async_trait::async_trait;
+use github::Github;
+use serde_json::Value;
+
+mod github;
+
+pub struct ReviewInfo {
+    pub diff: String,
+    pub commit: String,
+}
+
+#[async_trait]
+pub trait Backend {
+    async fn get_pr_info(&self, owner: &str, repo: &str, pr_num: u64) -> Result<ReviewInfo>;
+    async fn submit_review(&self, owner: &str, repo: &str, pr_num: u64, body: &Value)
+        -> Result<()>;
+
+    async fn submit_file_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_num: u64,
+        commit_id: &str,
+        fc: &FileComment,
+    ) -> Result<()>;
+}
+
+pub fn new_backend(config: &Config) -> Result<Box<dyn Backend>> {
+    Ok(Box::new(Github::new(config)?))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+mod backend;
 mod parser;
 mod prr;
 mod review;


### PR DESCRIPTION
A first step into adding different SCM backend (I'm aiming to add Gitlab support).

What do you think? I can stack a few PR until I get Gitlab working if you want to hold on merging the refactor.

But if I get a Gitlab backend implementation, would you be willing to merge this?

Ref: #17