### PR TITLE
Allow statically linking openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.2.1+3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +941,7 @@ checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,8 @@ xdg = "2.4"
 
 [dev-dependencies]
 tempfile = "3.8.1"
+
+[features]
+# Statically link a vendored copy OpenSSL. OpenSSL is used by all of `git2`, `reqwest` and
+# `octocrab`, enabling vendoring for just one of them should be enough.
+vendored-openssl = ["git2/vendored-openssl"]


### PR DESCRIPTION
This is mostly to allow hassle-free installation on NixOS and such. Attentive reader might ask: why not rustls then? At the time of writing, octocrab and reqwest support rustls, but git2 does not. It might be a good idea to try to switch to gitoxide in lie of git2, but that's going to be a larger change!