### PR TITLE
src/prr: remove check for dirty repo

### DIFF
--- a/src/prr.rs
+++ b/src/prr.rs
@@ -416,7 +416,6 @@ impl Prr {
 
         // Best effort check to prevent clobbering any work in progress
         let mut status_opts = StatusOptions::new();
-        status_opts.include_untracked(true);
         let statuses = repo
             .statuses(Some(&mut status_opts))
             .context("Failed to get repo status")?;


### PR DESCRIPTION
A diff application cannot irreversibly destroy any state, because it
will fail atomically if a diff cannot be applied.

That means we don't need to check the state of the repo before applying.

It also means that the Apply functionality will actually be useful for
me because I usually have untracked files in my repo that otherwise will
prevent me from using Apply.
