### PR TITLE
Fix crate name in install_binary.md

### DIFF
--- a/book/src/install_binary.md
+++ b/book/src/install_binary.md
@@ -15,7 +15,7 @@ install `prr`:
 cargo install prr
 ```
 
-This will automatically download mdBook from [crates.io][1], build it, and
+This will automatically download `prr` from [crates.io][1], build it, and
 install it in Cargo's global binary directory (`~/.cargo/bin/` by default).
 
 To uninstall, run the command:


### PR DESCRIPTION
It said mdBook instead of prr.