### PR TITLE
Skip snip resolution if snips not used

### DIFF
--- a/src/review.rs
+++ b/src/review.rs
@@ -386,6 +386,15 @@ impl Review {
         // known as the "pattern" we want to resolve against original text.
         let pattern: Vec<LineType> = contents.lines().map(LineType::from).collect();
 
+        // If the review file does not have any snips, just skip snip resolution.
+        //
+        // We do this so user gets more informative error message thru validate_review_file()
+        // if they corrupted a quoted line. If we naively (and more efficiently) always
+        // try to resolve snips, they might get the less informative error below.
+        if !pattern.iter().any(|line| matches!(line, LineType::Snip)) {
+            return Ok(contents.to_string());
+        }
+
         // Next, store original text as lines. It's easier to index into this way.
         // The original text here is unquoted.
         let original = self.metadata()?.original;


### PR DESCRIPTION
This helps provide a better error message for the user. Cuz if user corrupts quoted text and snip resolution is attempted, they'll get a generic:

        Failed to resolve snips. Did you corrupt quoted text?

But if they hadn't used any snips, then they'll hit the validate_review_file() error check which provides line numbers and other helpful details.

This closes #49.