### PR TITLE
Adjust documentation showcasing code suggestion

### DIFF
--- a/book/src/examples/spanned_inline_comment.md
+++ b/book/src/examples/spanned_inline_comment.md
@@ -36,11 +36,6 @@
     be removed.
 
     ```suggestion
-    -asdf
-    -asdf
-    -asdf
-    -adsf
-    -
     ```
 
     [0]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/incorporating-feedback-in-your-pull-request


### PR DESCRIPTION
It turns out code suggestions are interpreted by GitHub without any
addition (+) or deletion (-) markers. You simply have to attach a code
suggestion to a span with the updated code, and GitHub will calculate
the diff and render it.
