### PR TITLE
Use get_review() over get_pr() when removing reviews

### DIFF
--- a/src/prr.rs
+++ b/src/prr.rs
@@ -477,7 +477,7 @@ impl Prr {
     pub async fn remove(&self, prs: &[String], force: bool, submitted: bool) -> Result<()> {
         for pr in prs {
             let (owner, repo, pr_num) = self.parse_pr_str(pr)?;
-            let review = self.get_pr(&owner, &repo, pr_num, force).await?;
+            let review = self.get_review(&owner, &repo, pr_num)?;
             review
                 .remove(force)
                 .with_context(|| anyhow!("Failed to remove {}", pr))?;


### PR DESCRIPTION
get_pr() downloads the PR and then deletes it. First, this does not work if the user is offline. Second, it's wasteful - why download then delete?

So use get_review() instead so we actually fetch an existing review.