### PR TITLE
build: enable completion and manpage generation by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: cargo test --verbose --no-run --features clap_mangen,clap_complete
+      run: cargo test --verbose --no-run
     - name: Run tests
       run: cargo test --verbose
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ tempfile = "3.8.1"
 [build-dependencies]
 anyhow = "1.0"
 clap = { version = "4.4", features = ["derive"] }
-clap_mangen = { version = "0.2.20", optional = true }
-clap_complete = { version = "4.5.2", optional = true }
+clap_complete = "4.5.2"
+clap_mangen = "0.2.20"
 
 [features]
 # Statically link a vendored copy OpenSSL. OpenSSL is used by all of `git2`, `reqwest` and

--- a/build.rs
+++ b/build.rs
@@ -24,21 +24,15 @@ fn main() -> std::io::Result<()> {
             .about("Mailing list style code reviews for GitHub")
             .long_about(LONG_ABOUT);
 
-        #[cfg(feature = "clap_mangen")]
-        {
-            let man_dir = std::path::Path::join(&out_dir, "man");
-            std::fs::create_dir_all(&man_dir)?;
-            clap_mangen::generate_to(cmd.clone(), &man_dir)?;
-        }
+        let man_dir = std::path::Path::join(&out_dir, "man");
+        std::fs::create_dir_all(&man_dir)?;
+        clap_mangen::generate_to(cmd.clone(), &man_dir)?;
 
-        #[cfg(feature = "clap_complete")]
-        {
-            use clap::ValueEnum;
-            let completions_dir = std::path::Path::join(&out_dir, "completions");
-            std::fs::create_dir_all(&completions_dir)?;
-            for shell in clap_complete::Shell::value_variants() {
-                clap_complete::generate_to(*shell, &mut cmd, "prr", &completions_dir)?;
-            }
+        use clap::ValueEnum;
+        let completions_dir = std::path::Path::join(&out_dir, "completions");
+        std::fs::create_dir_all(&completions_dir)?;
+        for shell in clap_complete::Shell::value_variants() {
+            clap_complete::generate_to(*shell, &mut cmd, "prr", &completions_dir)?;
         }
     }
 
@@ -47,8 +41,6 @@ fn main() -> std::io::Result<()> {
         std::env::var("TARGET").unwrap()
     );
     println!("cargo:rerun-if-env-changed=GEN_DIR");
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_CLAP_MANGEN");
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_CLAP_COMPLETE");
 
     Ok(())
 }


### PR DESCRIPTION
👋 I believe it’s generally better to generate completions and the man page by default whenever building the binary, rather than gating them behind feature flags. This simplifies the workflow and ensures all necessary assets are always available. 

Let me know what you think, thanks!