### PR TITLE
vim: fix highlighting

### DIFF
--- a/vim/ftplugin/prr.vim
+++ b/vim/ftplugin/prr.vim
@@ -10,10 +10,6 @@ function! DiffFoldLevel()
         return '>1'
     elseif l:line =~# '^> \(@@\|\d\)' " hunk
         return '>2'
-    elseif l:line =~# '^> \*\*\* \d\+,\d\+ \*\*\*\*$' " context: file1
-        return '>2'
-    elseif l:line =~# '^> --- \d\+,\d\+ ----$' " context: file2
-        return '>2'
     else
         return '='
     endif

--- a/vim/ftplugin/prr.vim
+++ b/vim/ftplugin/prr.vim
@@ -1,9 +1,9 @@
 setlocal foldmethod=expr
-setlocal foldexpr=DiffFoldLevel()
+setlocal foldexpr=s:DiffFoldLevel()
 setlocal foldcolumn=3
 
 " Adapted from https://github.com/sgeb/vim-diff-fold
-function! DiffFoldLevel()
+function! s:DiffFoldLevel()
     let l:line=getline(v:lnum)
 
     if l:line =~# '^> \(diff\|Index\)' " file

--- a/vim/ftplugin/prr.vim
+++ b/vim/ftplugin/prr.vim
@@ -1,3 +1,22 @@
-setlocal foldmethod=syntax
+setlocal foldmethod=expr
+setlocal foldexpr=DiffFoldLevel()
+setlocal foldcolumn=3
+
+" Adapted from https://github.com/sgeb/vim-diff-fold
+function! DiffFoldLevel()
+    let l:line=getline(v:lnum)
+
+    if l:line =~# '^> \(diff\|Index\)' " file
+        return '>1'
+    elseif l:line =~# '^> \(@@\|\d\)' " hunk
+        return '>2'
+    elseif l:line =~# '^> \*\*\* \d\+,\d\+ \*\*\*\*$' " context: file1
+        return '>2'
+    elseif l:line =~# '^> --- \d\+,\d\+ ----$' " context: file2
+        return '>2'
+    else
+        return '='
+    endif
+endfunction
 
 let b:undo_ftplugin = 'setl fdm&'

--- a/vim/ftplugin/prr.vim
+++ b/vim/ftplugin/prr.vim
@@ -15,4 +15,4 @@ function! DiffFoldLevel()
     endif
 endfunction
 
-let b:undo_ftplugin = 'setl fdm&'
+let b:undo_ftplugin = 'setl fdm< | setl fde< | setl fdc<'

--- a/vim/syntax/prr.vim
+++ b/vim/syntax/prr.vim
@@ -26,8 +26,8 @@ syn keyword prrResult approve reject comment
 
 " Define the default highlighting.
 " Only used when an item doesn't have highlighting yet
-hi def link prrAdded           Identifier
-hi def link prrRemoved         Special
+hi def link prrAdded           Added
+hi def link prrRemoved         Removed
 
 hi def link prrTagName Keyword
 hi def link prrResult String

--- a/vim/syntax/prr.vim
+++ b/vim/syntax/prr.vim
@@ -10,21 +10,19 @@ if exists("b:current_syntax")
   finish
 endif
 
-syn region prrFile start=/^> diff/ end=/^> diff/ms=s-1,me=s-1 transparent fold keepend contains=prrHeader,prrIndex,prrChunk
+" match + but not +++
+syn match prrAdded   "^> +\(++\)\@!.*"
+" match - but not ---
+syn match prrRemoved "^> -\(--\)\@!.*"
 
-syn region prrChunk start=/^> @@/ start=/^\n> /rs=e-2 end=/^> @@/ms=s-1,me=s-1 end=/^> diff/ms=s-1,me=s-1 end=/^$/ transparent fold keepend contains=CONTAINED,prrTag
-
-syn match prrAdded   contained "^> +.*"
-syn match prrRemoved contained "^> -.*"
-
-syn match prrHeader contained "^> diff.*"
-syn match prrIndex contained "^> index.*"
-syn match prrChunkH contained "^> @@.*"
+syn match prrHeader "^> diff --git .*"
+syn match prrIndex "^> index \w*\.\.\w*\( \w*\)\?"
+syn match prrChunkH "^> @@ .* @@"
 
 syn match prrTag "^@.*" contains=prrTagName,prrResult transparent
 
-syn match prrTagName contained "@prr" nextgroup=prrResult
-syn keyword prrResult contained approve reject comment
+syn match prrTagName "@prr" nextgroup=prrResult
+syn keyword prrResult approve reject comment
 
 " Define the default highlighting.
 " Only used when an item doesn't have highlighting yet


### PR DESCRIPTION
I was running into some highlighting issues as shown in this [demo](https://asciinema.org/a/M3LwMg8ExJYdBhUxVVTqUoxeb).
I was able to fix it by replacing `foldmethod=syntax` with `foldmethod=expr` which allowed me to remove the `syn region` definitions in the syntax file.
The fold function is adapted from [vim-diff-fold](https://github.com/sgeb/vim-diff-fold/blob/master/ftplugin/diff.vim)

I took the liberty to make some `syn match` a bit more restrictive and also changed the highlight groups for `prrAdded` and `prrRemoved` to the standard diff groups which feels more natural when going through diffs.

Happy to discuss any modifications or improvement.
And thanks for this cool tool :smiley: 
