### PR TITLE
vim: improve keyword syntax matching

### DIFF
--- a/vim/syntax/prr.vim
+++ b/vim/syntax/prr.vim
@@ -19,7 +19,7 @@ syn match prrHeader "^> diff --git .*"
 syn match prrIndex "^> index \w*\.\.\w*\( \w*\)\?"
 syn match prrChunkH "^> @@ .* @@"
 
-syn match prrTag "^@.*" contains=prrTagName,prrResult transparent
+syn match prrTag "^@prr .*" contains=prrTagName,prrResult transparent
 
 syn match prrTagName contained "@prr" nextgroup=prrResult
 syn keyword prrResult contained approve reject comment

--- a/vim/syntax/prr.vim
+++ b/vim/syntax/prr.vim
@@ -21,8 +21,8 @@ syn match prrChunkH "^> @@ .* @@"
 
 syn match prrTag "^@.*" contains=prrTagName,prrResult transparent
 
-syn match prrTagName "@prr" nextgroup=prrResult
-syn keyword prrResult approve reject comment
+syn match prrTagName contained "@prr" nextgroup=prrResult
+syn keyword prrResult contained approve reject comment
 
 " Define the default highlighting.
 " Only used when an item doesn't have highlighting yet


### PR DESCRIPTION
Sorry, some small oversight on my part in previous PR.
Without `contained` the keywords like `comment` and `approve` would get highlighted anywhere.
With `contained` they get highlighted only on a line with `@prr`, as it was the case previously.

Edit: 2nd commit, might as well improve `prrTag` matching a bit while at it.