### PR TITLE
Adds support for providing a GitHub token via envvar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1093,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1226,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "toml",
@@ -1206,6 +1240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1354,6 +1397,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1413,18 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "secrecy"
@@ -1446,6 +1510,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ xdg = "2.4"
 [dev-dependencies]
 pretty_assertions = "1.4.0"
 tempfile = "3.8.1"
+serial_test = "3.2.0"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/book/src/config.md
+++ b/book/src/config.md
@@ -26,12 +26,25 @@ The following global configuration options are supported:
 The required `token` field is your Github Personal Authentical Token as a
 string.
 
-Example:
+Examples:
+
+```toml
+[prr]
+token = "$PRR_TOKEN"
+```
 
 ```toml
 [prr]
 token = "ghp_Kuzzzzzzzzzzzzdonteventryzzzzzzzzzzz"
 ```
+
+If `token` is absent, then the following environment variables will be checked in order and 
+the first token found will be used:
+
+- `GH_TOKEN`
+- `GITHUB_TOKEN`
+- `GH_ENTERPRISE_TOKEN`
+- `GITHUB_ENTERPRISE_TOKEN`
 
 ### The `workdir` field
 

--- a/book/src/install_config.md
+++ b/book/src/install_config.md
@@ -16,4 +16,12 @@ workdir = "/home/dxu/dev/review"
 EOF
 ```
 
+`token` can be provided in one of a few ways. In order of precedence:
+- Referencing an environment variable containing the token e.g. `$PRR_TOKEN`
+- Having `GH_TOKEN`, `GITHUB_TOKEN`, `GH_ENTERPRISE_TOKEN` or `GITHUB_ENTERPRISE_TOKEN` already defined in your environment
+- Passing the token value as-is
+
+If `token` is absent from the config, then the above environment variables will be checked in order and 
+the first token found will be used.
+
 Note `workdir` can be any directory. (You don't have to use my unix name)


### PR DESCRIPTION
Adds support for providing a GitHub via an environment variable:

- **Envvar passed in config**: if there's a string value passed to `token` that begins with `$`, treat it as an envvar and perform a lookup
- **Known envvar present in environment**: As per envvars in https://cli.github.com/manual/gh_help_environment, if there's no value set for `token` then look for `GH_TOKEN`, `GITHUB_TOKEN`, `GH_ENTERPRISE_TOKEN`, or `GITHUB_ENTERPRISE_TOKEN`, in that order, and use the first token found.
- **Any other string**: treat it like a token.

I've also added a whole bunch of tests for as many scenarios/permutations of this that I can think of, as well as added `serial_test` as a dev dependency so the envvar tests run sequentially to avoid envvar definitions/removals clobbering each other. Please let me know if I've missed anything!

Closes #61