### PR TITLE
feat: Auto-detect repo and PR from current git branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ To that end, `prr` introduces a new workflow for reviewing PRs:
 1. Mark up the review file using your favorite text editor
 1. Submit the review at your convenience
 
+When run from within a git repository on a branch associated with a PR, `prr`
+can auto-detect the repository and PR number—just run `prr get`, `prr edit`,
+or `prr submit` without arguments. This works with fork workflows too.
+
 The tool was born of frustration from using the point-and-click editor text
 boxes on PRs. I happen to do a lot of code review and tabbing to and from the
 browser to cross reference code from the changes was driving me nuts.

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -9,6 +9,10 @@ To that end, `prr` introduces a new workflow for reviewing PRs:
 1. Mark up the review file using your favorite text editor
 1. Submit the review at your convenience
 
+When run from within a git repository on a branch associated with a PR, `prr`
+can auto-detect the repository and PR number—just run `prr get`, `prr edit`,
+or `prr submit` without arguments. This works with fork workflows too.
+
 The tool was born of frustration from using the point-and-click editor text
 boxes on PRs. I happen to do a lot of code review and tabbing to and from the
 browser to cross reference code from the changes was driving me nuts.

--- a/book/src/config.md
+++ b/book/src/config.md
@@ -110,6 +110,14 @@ The optional `repository` field takes a string in format of
 If specified, you may omit the `${ORG}/${REPO}` from PR string arguments.
 For example, you may run `prr get 6` instead of `prr get danobi/prr/6`.
 
+> [!TIP]
+> As an alternative to configuring this field, you can omit the PR
+> argument entirely when running from a git repository. If you're on a branch
+> that has an associated PR, `prr` will auto-detect the owner, repo, and PR
+> number from the git remote and current branch name. This works with fork
+> workflows too — `prr` uses `upstream` (if present) to identify the repository,
+> and `origin` to identify your fork.
+
 
 Example:
 

--- a/book/src/config.md
+++ b/book/src/config.md
@@ -101,6 +101,8 @@ The following local configuration options are supported:
 * `[local]`
     * [`repository`](#the-repository-field)
     * [`workdir`](#the-local-workdir-field)
+    * [`upstream_remote`](#the-upstream_remote-field)
+    * [`origin_remote`](#the-origin_remote-field)
 
 ### The `repository` field
 
@@ -124,6 +126,31 @@ Example:
 ```toml
 [local]
 repository = "danobi/prr"
+```
+
+### The `upstream_remote` field
+
+The optional `upstream_remote` field overrides the git remote name that `prr`
+treats as the upstream repository when auto-detecting PRs. Defaults to
+`"upstream"`.
+
+Example:
+
+```toml
+[local]
+upstream_remote = "main-repo"
+```
+
+### The `origin_remote` field
+
+The optional `origin_remote` field overrides the git remote name that `prr`
+treats as your fork when auto-detecting PRs. Defaults to `"origin"`.
+
+Example:
+
+```toml
+[local]
+origin_remote = "my-fork"
 ```
 
 ### The local `workdir` field

--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -15,9 +15,21 @@ $ prr get danobi/prr-test-repo/6
 /home/dxu/dev/review/danobi/prr-test-repo/6.prr
 ```
 
-`prr-get` downloads a pull request onto your filesystem into what we call a
+`prr get` downloads a pull request onto your filesystem into what we call a
 "review file". On success, the path to the review file is printed to your
 terminal.
+
+> [!TIP]
+> If you're inside a git clone on a branch that has an associated PR,
+> you can omit the PR argument entirely—`prr` will auto-detect the repository
+> and PR number from the git remote and current branch:
+>
+> ```sh
+> $ prr get
+> ```
+>
+> This works with fork workflows too: `prr` uses the `upstream` remote (if present)
+> to identify the repository, and the `origin` remote to identify your fork.
 
 But to be sure, let's check our status:
 
@@ -32,12 +44,14 @@ Great! We've confirmed the review was downloaded.
 ### Mark up the review file
 
 Now that the review file is downloaded, let's mark it up. You can open
-the review file in your favorite editor or use `prr-edit` to automatically
+the review file in your favorite editor or use `prr edit` to automatically
 open it in `$EDITOR`.
 
 ```
 $ prr edit danobi/prr-test-repo/6
 ```
+
+(Or just `prr edit` if you're on the PR's branch.)
 
 Your editor should show the contents as something like this:
 
@@ -133,6 +147,8 @@ Do this by running:
 ```sh
 $ prr submit danobi/prr-test-repo/6
 ```
+
+(Or just `prr submit` if you're on the PR's branch.)
 
 On success there will not be any output. But just to be safe, let's confirm
 submission status:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,21 +8,21 @@ pub(crate) enum Command {
         /// Ignore unsubmitted review checks
         #[clap(short, long)]
         force: bool,
-        /// Pull request to review (eg. `danobi/prr/24`)
-        pr: String,
+        /// Pull request to review (eg. `danobi/prr/24`). Auto-detected if omitted.
+        pr: Option<String>,
         /// Open review file in $EDITOR after download
         #[clap(long)]
         open: bool,
     },
     /// Open an existing review in $EDITOR
     Edit {
-        /// Pull request to edit (eg. `danobi/prr/24`)
-        pr: String,
+        /// Pull request to edit (eg. `danobi/prr/24`). Auto-detected if omitted.
+        pr: Option<String>,
     },
     /// Submit a review
     Submit {
-        /// Pull request to review (eg. `danobi/prr/24`)
-        pr: String,
+        /// Pull request to review (eg. `danobi/prr/24`). Auto-detected if omitted.
+        pr: Option<String>,
         #[clap(short, long)]
         debug: bool,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,10 @@ async fn main() -> Result<()> {
 
     match args.command {
         Command::Get { pr, force, open } => {
-            let (owner, repo, pr_num) = prr.parse_pr_str(&pr)?;
+            let (owner, repo, pr_num) = match pr {
+                Some(pr_str) => prr.parse_pr_str(&pr_str)?,
+                None => prr.detect_pr().await?,
+            };
             let review = prr.get_pr(&owner, &repo, pr_num, force).await?;
             let path = review.path();
             println!("{}", path.display());
@@ -77,12 +80,18 @@ async fn main() -> Result<()> {
             }
         }
         Command::Edit { pr } => {
-            let (owner, repo, pr_num) = prr.parse_pr_str(&pr)?;
+            let (owner, repo, pr_num) = match pr {
+                Some(pr_str) => prr.parse_pr_str(&pr_str)?,
+                None => prr.detect_pr().await?,
+            };
             let review = prr.get_review(&owner, &repo, pr_num)?;
             open_review(&review.path()).context("Failed to open review file")?;
         }
         Command::Submit { pr, debug } => {
-            let (owner, repo, pr_num) = prr.parse_pr_str(&pr)?;
+            let (owner, repo, pr_num) = match pr {
+                Some(pr_str) => prr.parse_pr_str(&pr_str)?,
+                None => prr.detect_pr().await?,
+            };
             prr.submit_pr(&owner, &repo, pr_num, debug).await?;
         }
         Command::Apply { pr } => {

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -541,6 +541,142 @@ impl Prr {
 
         Ok(())
     }
+
+    /// Parses a GitHub remote URL and extracts owner/repo.
+    /// Supports both SSH (git@github.com:owner/repo.git) and
+    /// HTTPS (https://github.com/owner/repo.git) formats.
+    fn parse_github_remote_url(url: &str) -> Result<(String, String)> {
+        // Try SSH format: git@github.com:owner/repo.git
+        if let Some(rest) = url.strip_prefix("git@") {
+            if let Some(colon_pos) = rest.find(':') {
+                let path = &rest[colon_pos + 1..];
+                let path = path.strip_suffix(".git").unwrap_or(path);
+                let parts: Vec<&str> = path.split('/').collect();
+                if parts.len() >= 2 {
+                    return Ok((parts[0].to_string(), parts[1].to_string()));
+                }
+            }
+        }
+
+        // Try HTTPS format: https://github.com/owner/repo.git
+        if url.starts_with("http://") || url.starts_with("https://") {
+            let uri: Uri = url.parse().context("Failed to parse remote URL")?;
+            let path = uri.path().trim_start_matches('/');
+            let path = path.strip_suffix(".git").unwrap_or(path);
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() >= 2 {
+                return Ok((parts[0].to_string(), parts[1].to_string()));
+            }
+        }
+
+        bail!("Could not parse GitHub URL from remote: {}", url)
+    }
+
+    /// Detects owner/repo and head_owner from a git repository's remotes.
+    /// Returns (repo_owner, repo_name, head_owner) where:
+    /// - repo_owner/repo_name: the repo to query PRs from (upstream if exists, else origin)
+    /// - head_owner: the owner for the PR head branch (origin owner for forks, else repo_owner)
+    fn detect_repo_from_repository(repo: &Repository) -> Result<(String, String, String)> {
+        // Try to get upstream (the repo to query PRs from)
+        let upstream_info = repo.find_remote("upstream").ok().and_then(|r| {
+            r.url()
+                .and_then(|url| Self::parse_github_remote_url(url).ok())
+        });
+
+        // Try to get origin (where the user's branches are)
+        let origin_info = repo.find_remote("origin").ok().and_then(|r| {
+            r.url()
+                .and_then(|url| Self::parse_github_remote_url(url).ok())
+        });
+
+        match (upstream_info, origin_info) {
+            // Fork workflow: query upstream, but head is from origin owner
+            (Some((repo_owner, repo_name)), Some((head_owner, _))) => {
+                Ok((repo_owner, repo_name, head_owner))
+            }
+            // No upstream, use origin for everything
+            (None, Some((owner, repo_name))) => Ok((owner.clone(), repo_name, owner)),
+            // Only upstream (unusual), use it for everything
+            (Some((owner, repo_name)), None) => Ok((owner.clone(), repo_name, owner)),
+            // No remotes found
+            (None, None) => bail!("No 'upstream' or 'origin' remote found"),
+        }
+    }
+
+    /// Detects owner/repo and head_owner from git remotes in the current directory.
+    fn detect_repo_from_remote() -> Result<(String, String, String)> {
+        let repo = Repository::discover(".").context("Not in a git repository")?;
+        Self::detect_repo_from_repository(&repo)
+    }
+
+    /// Gets the branch name from a git repository's HEAD.
+    fn detect_branch_from_repository(repo: &Repository) -> Result<String> {
+        let head = repo.head().context("Failed to get HEAD reference")?;
+
+        if !head.is_branch() {
+            bail!("HEAD is not a branch (detached HEAD state)");
+        }
+
+        let branch_name = head
+            .shorthand()
+            .ok_or_else(|| anyhow!("Failed to get branch name"))?;
+
+        Ok(branch_name.to_string())
+    }
+
+    /// Gets the current git branch name from the current directory.
+    fn detect_current_branch() -> Result<String> {
+        let repo = Repository::discover(".").context("Not in a git repository")?;
+        Self::detect_branch_from_repository(&repo)
+    }
+
+    /// Finds the PR number for a given branch in a repo.
+    /// Queries GitHub API: GET /repos/{owner}/{repo}/pulls?head={head_owner}:{branch}
+    ///
+    /// - `owner`/`repo`: the repository to query PRs from
+    /// - `head_owner`: the owner of the head branch (may differ from `owner` for forks)
+    /// - `branch`: the branch name
+    pub async fn detect_pr_for_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        head_owner: &str,
+        branch: &str,
+    ) -> Result<u64> {
+        let prs = self
+            .crab
+            .pulls(owner, repo)
+            .list()
+            .head(format!("{}:{}", head_owner, branch))
+            .send()
+            .await
+            .context("Failed to query GitHub for PRs")?;
+
+        let items: Vec<_> = prs.items.into_iter().collect();
+
+        if items.is_empty() {
+            bail!(
+                "No open PR found for branch '{}' in {}/{}",
+                branch,
+                owner,
+                repo
+            );
+        }
+
+        // Return the first PR if multiple exist
+        Ok(items[0].number)
+    }
+
+    /// Auto-detects owner, repo, and PR number from current git state.
+    pub async fn detect_pr(&self) -> Result<(String, String, u64)> {
+        let (owner, repo, head_owner) = Self::detect_repo_from_remote()?;
+        let branch = Self::detect_current_branch()?;
+        let pr_num = self
+            .detect_pr_for_branch(&owner, &repo, &head_owner, &branch)
+            .await?;
+
+        Ok((owner, repo, pr_num))
+    }
 }
 
 #[cfg(test)]
@@ -927,5 +1063,183 @@ mod tests {
         let want_after_apply = fs::read("testdata/testgitrepo/README-applied.md")
             .expect("failed to read README-applied.md");
         assert_eq!(got_after_apply, want_after_apply);
+    }
+
+    #[test]
+    fn test_parse_github_remote_url_ssh() {
+        let result = Prr::parse_github_remote_url("git@github.com:danobi/prr.git").unwrap();
+        assert_eq!(result, ("danobi".to_string(), "prr".to_string()));
+    }
+
+    #[test]
+    fn test_parse_github_remote_url_ssh_no_git_suffix() {
+        let result = Prr::parse_github_remote_url("git@github.com:danobi/prr").unwrap();
+        assert_eq!(result, ("danobi".to_string(), "prr".to_string()));
+    }
+
+    #[test]
+    fn test_parse_github_remote_url_https() {
+        let result = Prr::parse_github_remote_url("https://github.com/danobi/prr.git").unwrap();
+        assert_eq!(result, ("danobi".to_string(), "prr".to_string()));
+    }
+
+    #[test]
+    fn test_parse_github_remote_url_https_no_git_suffix() {
+        let result = Prr::parse_github_remote_url("https://github.com/danobi/prr").unwrap();
+        assert_eq!(result, ("danobi".to_string(), "prr".to_string()));
+    }
+
+    #[test]
+    fn test_parse_github_remote_url_enterprise_ssh() {
+        let result = Prr::parse_github_remote_url("git@github.acme.com:org/repo.git").unwrap();
+        assert_eq!(result, ("org".to_string(), "repo".to_string()));
+    }
+
+    #[test]
+    fn test_parse_github_remote_url_enterprise_https() {
+        let result = Prr::parse_github_remote_url("https://github.acme.com/org/repo.git").unwrap();
+        assert_eq!(result, ("org".to_string(), "repo".to_string()));
+    }
+
+    #[test]
+    fn test_parse_github_remote_url_invalid() {
+        let result = Prr::parse_github_remote_url("not-a-valid-url");
+        assert!(result.is_err());
+    }
+
+    /// Helper to create a temp git repo with an initial commit
+    fn create_temp_git_repo() -> (git2::Repository, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        // Create an initial commit so HEAD exists
+        {
+            let sig = git2::Signature::now("test", "test@test.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
+                .unwrap();
+        }
+
+        (repo, dir)
+    }
+
+    #[test]
+    fn test_detect_repo_from_repository_ssh() {
+        let (repo, _dir) = create_temp_git_repo();
+        repo.remote("origin", "git@github.com:testowner/testrepo.git")
+            .unwrap();
+
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        assert_eq!(owner, "testowner");
+        assert_eq!(repo_name, "testrepo");
+        assert_eq!(head_owner, "testowner"); // Same as owner when no upstream
+    }
+
+    #[test]
+    fn test_detect_repo_from_repository_https() {
+        let (repo, _dir) = create_temp_git_repo();
+        repo.remote("origin", "https://github.com/testowner/testrepo.git")
+            .unwrap();
+
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        assert_eq!(owner, "testowner");
+        assert_eq!(repo_name, "testrepo");
+        assert_eq!(head_owner, "testowner"); // Same as owner when no upstream
+    }
+
+    #[test]
+    fn test_detect_repo_from_repository_no_remote() {
+        let (repo, _dir) = create_temp_git_repo();
+        // Don't add any remote
+
+        let result = Prr::detect_repo_from_repository(&repo);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("upstream") || err_msg.contains("origin"));
+    }
+
+    #[test]
+    fn test_detect_repo_from_repository_fork_workflow() {
+        let (repo, _dir) = create_temp_git_repo();
+        repo.remote("origin", "git@github.com:myuser/fork.git")
+            .unwrap();
+        repo.remote(
+            "upstream",
+            "git@github.com:upstream-owner/upstream-repo.git",
+        )
+        .unwrap();
+
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        assert_eq!(owner, "upstream-owner"); // Repo to query PRs from
+        assert_eq!(repo_name, "upstream-repo");
+        assert_eq!(head_owner, "myuser"); // Head owner is from origin (the fork)
+    }
+
+    #[test]
+    fn test_detect_repo_from_repository_falls_back_to_origin() {
+        let (repo, _dir) = create_temp_git_repo();
+        repo.remote("origin", "git@github.com:myuser/myrepo.git")
+            .unwrap();
+        // No upstream remote
+
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        assert_eq!(owner, "myuser");
+        assert_eq!(repo_name, "myrepo");
+        assert_eq!(head_owner, "myuser"); // Same as owner when no upstream
+    }
+
+    #[test]
+    fn test_detect_repo_from_repository_only_upstream() {
+        let (repo, _dir) = create_temp_git_repo();
+        repo.remote(
+            "upstream",
+            "git@github.com:upstream-owner/upstream-repo.git",
+        )
+        .unwrap();
+        // No origin remote (unusual but possible)
+
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        assert_eq!(owner, "upstream-owner");
+        assert_eq!(repo_name, "upstream-repo");
+        assert_eq!(head_owner, "upstream-owner"); // Same as owner when no origin
+    }
+
+    #[test]
+    fn test_detect_branch_from_repository_master() {
+        let (repo, _dir) = create_temp_git_repo();
+        // Default branch after init with a commit is master (or main depending on git config)
+
+        let result = Prr::detect_branch_from_repository(&repo).unwrap();
+        // Could be "master" or "main" depending on git version/config
+        assert!(result == "master" || result == "main");
+    }
+
+    #[test]
+    fn test_detect_branch_from_repository_feature_branch() {
+        let (repo, _dir) = create_temp_git_repo();
+
+        // Create and checkout a new branch
+        let head = repo.head().unwrap();
+        let commit = head.peel_to_commit().unwrap();
+        repo.branch("feature-branch", &commit, false).unwrap();
+        repo.set_head("refs/heads/feature-branch").unwrap();
+
+        let result = Prr::detect_branch_from_repository(&repo).unwrap();
+        assert_eq!(result, "feature-branch");
+    }
+
+    #[test]
+    fn test_detect_branch_from_repository_detached_head() {
+        let (repo, _dir) = create_temp_git_repo();
+
+        // Detach HEAD by checking out a commit directly
+        let head = repo.head().unwrap();
+        let commit = head.peel_to_commit().unwrap();
+        repo.set_head_detached(commit.id()).unwrap();
+
+        let result = Prr::detect_branch_from_repository(&repo);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("detached HEAD"));
     }
 }

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -669,17 +669,22 @@ impl Prr {
 
         let items: Vec<_> = prs.items.into_iter().collect();
 
-        if items.is_empty() {
-            bail!(
-                "No open PR found for branch '{}' in {}/{}",
+        match items.len() {
+            0 => bail!(
+                "No open PR found for branch \'{}\' in {}/{}",
                 branch,
                 owner,
                 repo
-            );
+            ),
+            1 => Ok(items[0].number),
+            n => bail!(
+                "Found {} open PRs for branch \'{}\' in {}/{}; specify the PR explicitly",
+                n,
+                branch,
+                owner,
+                repo
+            ),
         }
-
-        // Return the first PR if multiple exist
-        Ok(items[0].number)
     }
 
     /// Auto-detects owner, repo, and PR number from current git state.
@@ -1153,7 +1158,8 @@ mod tests {
         repo.remote("origin", "git@github.com:testowner/testrepo.git")
             .unwrap();
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
+        let (owner, repo_name, head_owner) =
+            Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "testowner");
         assert_eq!(repo_name, "testrepo");
         assert_eq!(head_owner, "testowner"); // Same as owner when no upstream
@@ -1165,7 +1171,8 @@ mod tests {
         repo.remote("origin", "https://github.com/testowner/testrepo.git")
             .unwrap();
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
+        let (owner, repo_name, head_owner) =
+            Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "testowner");
         assert_eq!(repo_name, "testrepo");
         assert_eq!(head_owner, "testowner"); // Same as owner when no upstream
@@ -1193,7 +1200,8 @@ mod tests {
         )
         .unwrap();
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
+        let (owner, repo_name, head_owner) =
+            Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "upstream-owner"); // Repo to query PRs from
         assert_eq!(repo_name, "upstream-repo");
         assert_eq!(head_owner, "myuser"); // Head owner is from origin (the fork)
@@ -1206,7 +1214,8 @@ mod tests {
             .unwrap();
         // No upstream remote
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
+        let (owner, repo_name, head_owner) =
+            Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "myuser");
         assert_eq!(repo_name, "myrepo");
         assert_eq!(head_owner, "myuser"); // Same as owner when no upstream
@@ -1222,12 +1231,12 @@ mod tests {
         .unwrap();
         // No origin remote (unusual but possible)
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
+        let (owner, repo_name, head_owner) =
+            Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "upstream-owner");
         assert_eq!(repo_name, "upstream-repo");
         assert_eq!(head_owner, "upstream-owner"); // Same as owner when no origin
     }
-
 
     #[test]
     fn test_detect_repo_from_repository_custom_remote_names() {

--- a/src/prr.rs
+++ b/src/prr.rs
@@ -86,6 +86,10 @@ struct PrrLocalConfig {
     repository: Option<String>,
     /// Local workdir override
     workdir: Option<String>,
+    /// Override the git remote name used as the upstream repo (default: "upstream")
+    upstream_remote: Option<String>,
+    /// Override the git remote name used as the origin/fork repo (default: "origin")
+    origin_remote: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -576,15 +580,19 @@ impl Prr {
     /// Returns (repo_owner, repo_name, head_owner) where:
     /// - repo_owner/repo_name: the repo to query PRs from (upstream if exists, else origin)
     /// - head_owner: the owner for the PR head branch (origin owner for forks, else repo_owner)
-    fn detect_repo_from_repository(repo: &Repository) -> Result<(String, String, String)> {
+    fn detect_repo_from_repository(
+        repo: &Repository,
+        upstream_remote: &str,
+        origin_remote: &str,
+    ) -> Result<(String, String, String)> {
         // Try to get upstream (the repo to query PRs from)
-        let upstream_info = repo.find_remote("upstream").ok().and_then(|r| {
+        let upstream_info = repo.find_remote(upstream_remote).ok().and_then(|r| {
             r.url()
                 .and_then(|url| Self::parse_github_remote_url(url).ok())
         });
 
         // Try to get origin (where the user's branches are)
-        let origin_info = repo.find_remote("origin").ok().and_then(|r| {
+        let origin_info = repo.find_remote(origin_remote).ok().and_then(|r| {
             r.url()
                 .and_then(|url| Self::parse_github_remote_url(url).ok())
         });
@@ -599,14 +607,21 @@ impl Prr {
             // Only upstream (unusual), use it for everything
             (Some((owner, repo_name)), None) => Ok((owner.clone(), repo_name, owner)),
             // No remotes found
-            (None, None) => bail!("No 'upstream' or 'origin' remote found"),
+            (None, None) => bail!(
+                "No '{}' or '{}' remote found",
+                upstream_remote,
+                origin_remote
+            ),
         }
     }
 
     /// Detects owner/repo and head_owner from git remotes in the current directory.
-    fn detect_repo_from_remote() -> Result<(String, String, String)> {
+    fn detect_repo_from_remote(
+        upstream_remote: &str,
+        origin_remote: &str,
+    ) -> Result<(String, String, String)> {
         let repo = Repository::discover(".").context("Not in a git repository")?;
-        Self::detect_repo_from_repository(&repo)
+        Self::detect_repo_from_repository(&repo, upstream_remote, origin_remote)
     }
 
     /// Gets the branch name from a git repository's HEAD.
@@ -669,7 +684,15 @@ impl Prr {
 
     /// Auto-detects owner, repo, and PR number from current git state.
     pub async fn detect_pr(&self) -> Result<(String, String, u64)> {
-        let (owner, repo, head_owner) = Self::detect_repo_from_remote()?;
+        let local = self.config.local.as_ref();
+        let upstream_remote = local
+            .and_then(|l| l.upstream_remote.as_deref())
+            .unwrap_or("upstream");
+        let origin_remote = local
+            .and_then(|l| l.origin_remote.as_deref())
+            .unwrap_or("origin");
+        let (owner, repo, head_owner) =
+            Self::detect_repo_from_remote(upstream_remote, origin_remote)?;
         let branch = Self::detect_current_branch()?;
         let pr_num = self
             .detect_pr_for_branch(&owner, &repo, &head_owner, &branch)
@@ -1130,7 +1153,7 @@ mod tests {
         repo.remote("origin", "git@github.com:testowner/testrepo.git")
             .unwrap();
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "testowner");
         assert_eq!(repo_name, "testrepo");
         assert_eq!(head_owner, "testowner"); // Same as owner when no upstream
@@ -1142,7 +1165,7 @@ mod tests {
         repo.remote("origin", "https://github.com/testowner/testrepo.git")
             .unwrap();
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "testowner");
         assert_eq!(repo_name, "testrepo");
         assert_eq!(head_owner, "testowner"); // Same as owner when no upstream
@@ -1153,7 +1176,7 @@ mod tests {
         let (repo, _dir) = create_temp_git_repo();
         // Don't add any remote
 
-        let result = Prr::detect_repo_from_repository(&repo);
+        let result = Prr::detect_repo_from_repository(&repo, "upstream", "origin");
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("upstream") || err_msg.contains("origin"));
@@ -1170,7 +1193,7 @@ mod tests {
         )
         .unwrap();
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "upstream-owner"); // Repo to query PRs from
         assert_eq!(repo_name, "upstream-repo");
         assert_eq!(head_owner, "myuser"); // Head owner is from origin (the fork)
@@ -1183,7 +1206,7 @@ mod tests {
             .unwrap();
         // No upstream remote
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "myuser");
         assert_eq!(repo_name, "myrepo");
         assert_eq!(head_owner, "myuser"); // Same as owner when no upstream
@@ -1199,10 +1222,34 @@ mod tests {
         .unwrap();
         // No origin remote (unusual but possible)
 
-        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo).unwrap();
+        let (owner, repo_name, head_owner) = Prr::detect_repo_from_repository(&repo, "upstream", "origin").unwrap();
         assert_eq!(owner, "upstream-owner");
         assert_eq!(repo_name, "upstream-repo");
         assert_eq!(head_owner, "upstream-owner"); // Same as owner when no origin
+    }
+
+
+    #[test]
+    fn test_detect_repo_from_repository_custom_remote_names() {
+        let (repo, _dir) = create_temp_git_repo();
+        repo.remote("my-fork", "git@github.com:myuser/fork.git")
+            .unwrap();
+        repo.remote(
+            "main-repo",
+            "git@github.com:upstream-owner/upstream-repo.git",
+        )
+        .unwrap();
+
+        // Using default remote names should fail (no "upstream" or "origin")
+        let result = Prr::detect_repo_from_repository(&repo, "upstream", "origin");
+        assert!(result.is_err());
+
+        // Using custom remote names should work
+        let (owner, repo_name, head_owner) =
+            Prr::detect_repo_from_repository(&repo, "main-repo", "my-fork").unwrap();
+        assert_eq!(owner, "upstream-owner");
+        assert_eq!(repo_name, "upstream-repo");
+        assert_eq!(head_owner, "myuser");
     }
 
     #[test]


### PR DESCRIPTION
This change enables running `prr get`, `prr edit`, or `prr submit` without an argument — in which case, `prr` now auto-detects the repo and PR number by:

1. Parsing the git remote URL: tries _“upstream”_ first (for fork workflows), then, if that's not found, falls back to _“origin”._
2. Getting the current branch name.
3. Querying the GitHub API for the PR associated with that branch.

When invoked from inside a GitHub repo clone on a PR branch, all that enables you to just run `prr get`, `prr edit`, or `prr submit` with no argument.
