### PR TITLE
fix: add leading slash to API URI paths

### DIFF
--- a/src/prr.rs
+++ b/src/prr.rs
@@ -388,7 +388,7 @@ impl Prr {
         pr_num: u64,
         body: &Value,
     ) -> Result<()> {
-        let path = format!("repos/{}/{}/pulls/{}/reviews", owner, repo, pr_num);
+        let path = format!("/repos/{}/{}/pulls/{}/reviews", owner, repo, pr_num);
         let uri = Uri::builder()
             .path_and_query(path)
             .build()
@@ -438,7 +438,7 @@ impl Prr {
             "path": fc.file,
             "subject_type": "file",
         });
-        let path = format!("repos/{}/{}/pulls/{}/comments", owner, repo, pr_num);
+        let path = format!("/repos/{}/{}/pulls/{}/comments", owner, repo, pr_num);
         let uri = Uri::builder()
             .path_and_query(path)
             .build()


### PR DESCRIPTION
## Summary

Fixes `prr submit` failing with `Error: Invalid URI` / `path does not start with slash`.

## Problem

`http::Uri::builder().path_and_query()` requires the path component to start with `/` per RFC 3986. Both `submit_review()` and `submit_file_comment()` in `src/prr.rs` constructed paths like `repos/owner/repo/pulls/123/reviews` without the leading slash, causing every submit attempt to fail.

## Fix

Added a leading `/` to the format strings in both locations in `src/prr.rs`.

Fixes #80

## Testing

Verified by piping the JSON output of `prr submit --debug 2>/dev/null` into `gh api --input -` which successfully submitted a review with 13 inline comments to a real PR.
